### PR TITLE
Configure git to handle line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# When text is set to "auto", the path is marked for automatic end-of-line conversion.
+# If Git decides that the content is text, its line endings are converted to LF on
+# checkin. When the file has been committed with CRLF, no conversion is done.
+# https://git-scm.com/docs/gitattributes
+* text=auto
+
+# Override default behavior: BAT, PowerShell files always have CRLF line endings.
+*.bat text eol=crlf
+*.ps1 text eol=crlf
+


### PR DESCRIPTION
Use .gitattributes to let git normalize line endings on commit for files it determine are text. Exceptions are made for .bat and .ps1 scripts, which should use windows line endings.