### PR TITLE
BTreeIF allows both BTree1 and BTree2

### DIFF
--- a/core/src/commonMain/kotlin/com/sunya/cdm/layout/Tiling.kt
+++ b/core/src/commonMain/kotlin/com/sunya/cdm/layout/Tiling.kt
@@ -14,7 +14,7 @@ import kotlin.math.min
  * @param varshape the variable's shape
  * @param chunk  actual data storage has this shape. May be larger than the shape, last dim ignored if rank > varshape.
  */
-internal class Tiling(varshape: LongArray, chunkIn: LongArray) {
+class Tiling(varshape: LongArray, chunkIn: LongArray) {
     val chunk = chunkIn.copyOf()
     val rank: Int
     val tileShape : LongArray // overall shape of the dataset's tile space

--- a/core/src/commonMain/kotlin/com/sunya/netchdf/hdf5/BTree2.kt
+++ b/core/src/commonMain/kotlin/com/sunya/netchdf/hdf5/BTree2.kt
@@ -2,20 +2,26 @@ package com.sunya.netchdf.hdf5
 
 import com.sunya.cdm.iosp.OpenFileIF
 import com.sunya.cdm.iosp.OpenFileState
+import com.sunya.cdm.layout.Tiling
 import com.sunya.cdm.util.InternalLibraryApi
+import com.sunya.netchdf.hdf5.BTree1.DataChunkEntry
+import com.sunya.netchdf.hdf5.BTree1.Node
 
 /**
  * Level 1A2
- * Used in readGroupNew( type 5 and 6), readAttributesFromInfoMessage(), FractalHeap, and DHeapId(type 1,2,3,4)
+ * TODO ?? Used in readGroupNew( type 5 and 6), readAttributesFromInfoMessage(), FractalHeap, and DHeapId(type 1,2,3,4)
  */
 @OptIn(InternalLibraryApi::class)
-internal class BTree2(private val h5: H5builder, owner: String, address: Long) {
+internal class BTree2(private val h5: H5builder, owner: String, address: Long, val ndimStorage: Int? = null) : BTreeIF { // BTree2
     val btreeType: Int
     private val nodeSize: Int // size in bytes of btree nodes
     private val recordSize: Short// size in bytes of btree records
     private val owner: String
     private val raf: OpenFileIF
-    val entryList: MutableList<Entry2> = ArrayList()
+    val rootNodeAddress: Long
+    val treeDepth : Short
+    val numRecordsRootNode : Short
+    val totalRecords: Long
 
     init {
         raf = h5.raf
@@ -27,43 +33,63 @@ internal class BTree2(private val h5: H5builder, owner: String, address: Long) {
         check(magic == "BTHD") { "$magic should equal BTHD" }
         val version: Byte = raf.readByte(state)
         btreeType = raf.readByte(state).toInt()
-        nodeSize = raf.readInt(state)
-        recordSize = raf.readShort(state)
-        val treeDepth: Short = raf.readShort(state)
-        state.pos += 2
-        val rootNodeAddress: Long = h5.readOffset(state)
-        val numRecordsRootNode: Short = raf.readShort(state)
-        val totalRecords: Long = h5.readLength(state) // total in entire btree
+        nodeSize = raf.readInt(state) // This is the size in bytes of all B-tree nodes.
+        recordSize = raf.readShort(state) // This field is the size in bytes of the B-tree record.
+        treeDepth = raf.readShort(state)
+
+        val splitPct = raf.readByte(state)
+        val mergePct = raf.readByte(state)
+        rootNodeAddress = h5.readOffset(state)
+        numRecordsRootNode = raf.readShort(state)
+
+        totalRecords = h5.readLength(state) // total in entire btree
         val checksum: Int = raf.readInt(state)
 
-        // eager reading of all nodes
-        if (treeDepth > 0) {
-            val node = InternalNode(rootNodeAddress, numRecordsRootNode, recordSize, treeDepth.toInt())
-            node.recurse()
-        } else {
-            val leaf = LeafNode(rootNodeAddress, numRecordsRootNode)
-            leaf.addEntries(entryList)
+        /*
+        if (rootNodeAddress > 0) {
+            // eager reading of all nodes TODO can cache in H5TiledData
+            if (treeDepth > 0) {
+                val node = InternalNode(rootNodeAddress, numRecordsRootNode, recordSize, treeDepth.toInt())
+                node.recurse()
+            } else {
+                val leaf = LeafNode(rootNodeAddress, numRecordsRootNode)
+                leaf.addEntries(entryList)
+            }
         }
+
+         */
     }
 
-    internal fun getEntry1(hugeObjectID: Int): Record1? {
-        for (entry in entryList) {
-            val record1 = entry.record as Record1?
-            if (record1!!.hugeObjectID == hugeObjectID.toLong()) return record1
+    override fun rootNodeAddress() = rootNodeAddress
+
+    override fun readNode(address: Long, parent: BTreeNodeIF?): BTreeNodeIF {
+        val nrecords = nodeSize / recordSize // ??
+        return LeafNode(address, nrecords.toShort()) as BTreeNodeIF
+    }
+
+    override fun makeMissingDataChunkEntry(rootNode: BTreeNodeIF, wantKey: LongArray): DataChunkEntryIF {
+        return DataChunkEntry(0, rootNode as Node, -1, BTree1.DataChunkKey(-1, 0, wantKey), -1L)
+    }
+
+    // read all the entries in; used for non-data btrees
+    fun readEntries() : List<Btree2Entry> {
+        val entryList = mutableListOf<Btree2Entry>()
+
+        if (rootNodeAddress > 0) {
+            if (treeDepth > 0) {
+                val node = InternalNode(rootNodeAddress, numRecordsRootNode, recordSize, treeDepth.toInt())
+                node.recurse(entryList)
+            } else {
+                val leaf = LeafNode(rootNodeAddress, numRecordsRootNode)
+                leaf.addEntries(entryList)
+            }
         }
-        return null
+
+        return entryList
     }
 
-    // these are part of the level 1A data structure, type = 0
-    class Entry2 {
-        var childAddress: Long = 0
-        var nrecords: Long = 0
-        var totNrecords: Long = 0
-        var record: Any? = null
-    }
-
-    internal inner class InternalNode(address: Long, nrecords: Short, recordSize: Short, val depth: Int) {
-        var entries: Array<Entry2?>
+    internal inner class InternalNode(address: Long, nrecords: Short, recordSize: Short, val depth: Int) : BTreeNodeIF {
+        var entries: Array<Btree2Entry?>
 
         init {
             val state = OpenFileState(h5.getFileOffset(address), false)
@@ -72,49 +98,62 @@ internal class BTree2(private val h5: H5builder, owner: String, address: Long) {
             val magic = raf.readString(state, 4)
             check(magic == "BTIN") { "$magic should equal BTIN" }
             val version: Byte = raf.readByte(state)
-            val nodeType = raf.readByte(state).toInt()
+            val nodeType = raf.readByte(state).toInt() // same as the B-tree type in the header
             check(nodeType == btreeType)
+
             entries = arrayOfNulls(nrecords + 1) // did i mention theres actually n+1 children?
             for (i in 0 until nrecords) {
-                entries[i] = Entry2()
+                entries[i] = Btree2Entry()
                 entries[i]!!.record = readRecord(state, btreeType)
             }
-            entries[nrecords.toInt()] = Entry2()
+            entries[nrecords.toInt()] = Btree2Entry()
 
-            val maxNumRecords = nodeSize / recordSize // guessing
-            val maxNumRecordsPlusDesc = nodeSize / recordSize // guessing
+            // Records: The size of this field is determined by the number of records for this node and the record size (from the header).
+            
+            // maximum possible number of records able to be stored in the child node.
+            val maxNumRecords = nodeSize / recordSize // TODO see long calculation description in Fields: Version 2 B-tree Internal Node
+            // maximum possible number of records able to be stored in the child node and its descendants
+            val maxNumRecordsPlusDesc = nodeSize / recordSize // TODO see long calculation description in Fields: Version 2 B-tree Internal Node
+
             for (i in 0 until nrecords + 1) {
                 val e = entries[i]
-                e!!.childAddress = h5.readOffset(state)
-                e.nrecords = h5.readVariableSizeUnsigned(state, 1) // readVariableSizeMax(maxNumRecords);
+                e!!.childAddress = h5.readOffset(state) // Child Node Pointer
+                e.nrecords = h5.readVariableSizeUnsigned(state, 1) // Number of Records for Child TODO maxNumRecords ??
                 if (depth > 1) {
                     e.totNrecords = h5.readVariableSizeUnsigned(state, 2)
-                } // readVariableSizeMax(maxNumRecordsPlusDesc);
+                } // readVariableSizeMax(maxNumRecordsPlusDesc); // TODO ??
             }
 
             // skip
             raf.readInt(state)
         }
 
-        fun recurse() {
-            for (e in entries) {
+        fun recurse(entryList : MutableList<Btree2Entry>) {
+            for (entry in entries) {
                 if (depth > 1) {
-                    val node = InternalNode(e!!.childAddress, e.nrecords.toShort(), recordSize, depth - 1)
-                    node.recurse()
+                    val node = InternalNode(entry!!.childAddress, entry.nrecords.toShort(), recordSize, depth - 1)
+                    node.recurse(entryList)
                 } else {
-                    val nrecs = e!!.nrecords
-                    val leaf = LeafNode(e.childAddress, nrecs.toShort())
+                    val nrecs = entry!!.nrecords
+                    val leaf = LeafNode(entry.childAddress, nrecs.toShort())
                     leaf.addEntries(entryList)
                 }
-                if (e.record != null) { // last one is null
-                    entryList.add(e)
+                if (entry.record != null) { // last one is null
+                    entryList.add(entry)
                 }
             }
         }
+
+        override fun isLeaf() = false
+        override fun nentries() = entries.size
+        override fun dataChunkEntryAt(idx: Int): DataChunkEntryIF {
+            throw RuntimeException("dataChunkEntryAt only for leaf nodes")
+        }
     }
 
-    internal inner class LeafNode(address: Long, nrecords: Short) {
-        val entries = mutableListOf<Entry2>()
+    // problem is we need nrecords. Thinking we can derive it from the recordSize?
+    internal inner class LeafNode(address: Long, nrecords: Short) : BTreeNodeIF {
+        val entries = mutableListOf<Btree2Entry>()
 
         init {
             val state = OpenFileState(h5.getFileOffset(address), false)
@@ -127,7 +166,7 @@ internal class BTree2(private val h5: H5builder, owner: String, address: Long) {
             check(nodeType == btreeType)
 
             for (i in 0 until nrecords) {
-                val entry = Entry2()
+                val entry = Btree2Entry()
                 entry.record = readRecord(state, btreeType)
                 entries.add(entry)
             }
@@ -136,8 +175,43 @@ internal class BTree2(private val h5: H5builder, owner: String, address: Long) {
             raf.readInt(state)
         }
 
-        fun addEntries(list: MutableList<Entry2>) {
+        fun addEntries(list: MutableList<Btree2Entry>) {
             list.addAll(entries)
+        }
+
+        override fun isLeaf() = true
+        override fun nentries() = entries.size
+        override fun dataChunkEntryAt(idx: Int) = entries[idx]
+    }
+
+    inner class Btree2Entry : DataChunkEntryIF {
+        var childAddress: Long = 0
+        var nrecords: Long = 0
+        var totNrecords: Long = 0
+        var record: Any? = null
+
+        override fun childAddress() = childAddress  // how is this used ?
+
+        override fun offsets(): LongArray {
+            if (record is Record10) return (record as Record10).scaledOffset
+            if (record is Record11) return (record as Record11).scaledOffset
+            throw RuntimeException("record type must be 10 or 11")
+        }
+
+        override fun isMissing() = (childAddress > 0)
+
+        override fun chunkSize(): Int {
+            if (record is Record11) return (record as Record11).chunkSize.toInt()
+            return recordSize.toInt()
+        }
+
+        override fun filterMask(): Int? {
+            if (record is Record11) return (record as Record11).filterMask
+            return null
+        }
+
+        override fun show(tiling: Tiling): String {
+            return "Not yet implemented"
         }
     }
 
@@ -152,8 +226,8 @@ internal class BTree2(private val h5: H5builder, owner: String, address: Long) {
             7 -> Record70(state) // TODO wrong
             8 -> Record8(state)
             9 -> Record9(state)
-            10 -> Record10(state, 0) // TODO wrong, whats ndims?
-            11 -> Record11(state, 0) // TODO wrong, whats ndims?
+            10 -> Record10(state, ndimStorage!!) // TODO wrong, whats ndims?
+            11 -> Record11(state, ndimStorage!!) // TODO wrong, whats ndims?
             else -> throw IllegalStateException()
         }
     }
@@ -234,16 +308,34 @@ internal class BTree2(private val h5: H5builder, owner: String, address: Long) {
     }
 
     // Type 10 Record Layout - Non-filtered Dataset Chunks
-    inner class Record10(state: OpenFileState, ndims : Int) {
+    inner class Record10(state: OpenFileState, rank : Int) {
         val address = h5.readOffset(state)
-        val dims = LongArray(ndims) { raf.readLong(state) }
+        // ooops forgot to put in the rank. silly goose
+        // This field is the scaled offset of the chunk within the dataset. n is the number of dimensions for the dataset.
+        // The first scaled offset stored in the list is for the slowest changing dimension, and the last scaled offset
+        // stored is for the fastest changing dimension. Scaled offset is calculated by dividing the chunk dimension sizes into the chunk offsets.
+        val scaledOffset = LongArray(rank) { raf.readLong(state) }
     }
 
     // Type 11 Record Layout - Filtered Dataset Chunks
-    inner class Record11(state: OpenFileState, ndims : Int) {
+    inner class Record11(state: OpenFileState, rank : Int) {
         val address = h5.readOffset(state)
         val chunkSize = raf.readLong(state) // LOOK variable size based on what ?
         val filterMask = raf.readInt(state)
-        val dims = LongArray(ndims) { raf.readLong(state) }
+        // ooops forgot to put in the rank. silly goose
+        // This field is the scaled offset of the chunk within the dataset. n is the number of dimensions for the dataset.
+        // The first scaled offset stored in the list is for the slowest changing dimension, and the last scaled offset
+        // stored is for the fastest changing dimension. Scaled offset is calculated by dividing the chunk dimension sizes into the chunk offsets.
+        val scaledOffset = LongArray(rank) { raf.readLong(state) }
     }
-} // BTree2
+
+    companion object {
+        internal fun findRecord1byId(entryList: List<Btree2Entry>, hugeObjectID: Int): Record1? {
+            for (entry in entryList) {
+                val record1 = entry.record as Record1?
+                if (record1!!.hugeObjectID == hugeObjectID.toLong()) return record1
+            }
+            return null
+        }
+    }
+}

--- a/core/src/commonMain/kotlin/com/sunya/netchdf/hdf5/BTreeIF.kt
+++ b/core/src/commonMain/kotlin/com/sunya/netchdf/hdf5/BTreeIF.kt
@@ -1,0 +1,25 @@
+package com.sunya.netchdf.hdf5
+
+import com.sunya.cdm.layout.Tiling
+
+interface BTreeIF {
+    fun rootNodeAddress() : Long
+    fun readNode(address: Long, parent: BTreeNodeIF?) : BTreeNodeIF
+    fun makeMissingDataChunkEntry(rootNode : BTreeNodeIF, wantKey : LongArray) : DataChunkEntryIF
+}
+
+interface BTreeNodeIF {
+    fun isLeaf(): Boolean
+    fun nentries(): Int
+    fun dataChunkEntryAt(idx: Int) : DataChunkEntryIF // only if isLeaf
+}
+
+interface DataChunkEntryIF {
+    fun childAddress(): Long
+    fun offsets(): LongArray
+    fun isMissing(): Boolean
+    fun chunkSize(): Int
+    fun filterMask(): Int?
+
+    fun show(tiling : Tiling): String
+}

--- a/core/src/commonMain/kotlin/com/sunya/netchdf/hdf5/H5cdmBuilder.kt
+++ b/core/src/commonMain/kotlin/com/sunya/netchdf/hdf5/H5cdmBuilder.kt
@@ -153,7 +153,7 @@ internal open class DataContainerAttribute(
 
 val mdlClassCount = getDataLayoutCounts()
 
-// TODO none of the version4 layouts are implemented
+// TODO ?? none of the version4 layouts are implemented
 internal class DataContainerVariable(
     override val name: String,
     override val h5type: H5TypeInfo,
@@ -180,7 +180,7 @@ internal class DataContainerVariable(
         // TODO if compact, do not use fileOffset
         dataPos = when (mdl) {
             is DataLayoutContiguous -> h5.getFileOffset(mdl.dataAddress)
-            is DataLayoutChunked -> mdl.btreeAddress // offset will be added in BTreeData
+            is DataLayoutBTreeVer1 -> mdl.btreeAddress // offset will be added in BTreeData
             is DataLayoutCompact -> -2L // data is in mdl.compactData
             is DataLayoutCompact3 -> -2L // data is in mdl.compactData
             is DataLayoutContiguous3 -> h5.getFileOffset(mdl.dataAddress)
@@ -208,7 +208,8 @@ internal class DataContainerVariable(
                 val nelems = this.storageDims.computeSize()
                 this.elementSize = (mdt.elemSize / nelems).toInt()
             }
-            is DataLayoutChunked -> {
+            is DataLayoutBTreeVer1 -> {
+                // println("file ${h5.raf.location()} var=${name} btreeVer1") // TODO ??
                 this.storageDims = mdl.chunkDims.toLongArray()
                 this.elementSize = storageDims[storageDims.size - 1].toInt() // last number is element size
             }

--- a/core/src/commonMain/kotlin/com/sunya/netchdf/hdf5/H5chunkIterator.kt
+++ b/core/src/commonMain/kotlin/com/sunya/netchdf/hdf5/H5chunkIterator.kt
@@ -28,8 +28,8 @@ internal class H5chunkIterator<T>(val h5 : H5builder, val v2: Variable<T>, val w
         elemSize = vinfo.storageDims[vinfo.storageDims.size - 1].toInt() // last one is always the elements size
         datatype = h5type.datatype()
 
-        val btreeNew = BTree1(h5, vinfo.dataPos, 1, v2.shape, vinfo.storageDims)
-        tiledData = H5TiledData(btreeNew)
+        val btreeNew = BTree1(h5, vinfo.dataPos, 1, vinfo.storageDims.size)
+        tiledData = H5TiledData(btreeNew, v2.shape, vinfo.storageDims)
         filters = H5filters(v2.name, vinfo.mfp, h5type.isBE)
         if (debugChunking) println(" H5chunkIterator tiles=${tiledData.tiling}")
 

--- a/core/src/commonMain/kotlin/com/sunya/netchdf/hdf5/H5group.kt
+++ b/core/src/commonMain/kotlin/com/sunya/netchdf/hdf5/H5group.kt
@@ -60,7 +60,7 @@ internal fun H5builder.readGroupNew(
 
         // read in btree and all entries
         val btree = BTree2(this, parent.name, btreeAddress)
-        for (e in btree.entryList) {
+        for (e in btree.readEntries()) {
             var heapId: ByteArray = when (btree.btreeType) {
                 5 -> (e.record as BTree2.Record5).heapId
                 6 -> (e.record as BTree2.Record6).heapId

--- a/core/src/commonMain/kotlin/com/sunya/netchdf/hdf5/Hdf5File.kt
+++ b/core/src/commonMain/kotlin/com/sunya/netchdf/hdf5/Hdf5File.kt
@@ -50,10 +50,12 @@ class Hdf5File(val filename : String, strict : Boolean = false) : Netchdf {
                 alldata.section(wantSection)
             } else if (vinfo.mdl.isContiguous) {
                 header.readRegularData(vinfo, v2.datatype, wantSection)
-            } else if (vinfo.mdl.isChunked) {
-                H5chunkReader(header).readChunkedData(v2, wantSection)
+           // } else if (vinfo.mdl is DataLayoutBTreeVer1) {
+           //     H5chunkReader(header).readBtreeVer1(v2, wantSection)
             } else if (vinfo.mdl is DataLayoutFixedArray4) {
                 H5chunkReader(header).readFixedArray(v2, wantSection)
+            } else if (vinfo.mdl is DataLayoutBTreeVer1 || vinfo.mdl is DataLayoutBtreeVer2) {
+                H5chunkReader(header).readBtreeVer12(v2, wantSection)
             } else {
                 throw RuntimeException("Unsupported data layer type ${vinfo.mdl}")
             }
@@ -76,7 +78,7 @@ class Hdf5File(val filename : String, strict : Boolean = false) : Netchdf {
             return listOf(single).iterator()
         }
 
-        return if (vinfo.mdl.isChunked) {
+        return if (vinfo.mdl is DataLayoutBTreeVer1) {
             H5chunkIterator(header, v2, wantSection)
         } else {
             H5maxIterator(this, v2, wantSection, maxElements ?: 100_000)

--- a/core/src/commonMain/kotlin/com/sunya/netchdf/hdf5/MessageHeader.kt
+++ b/core/src/commonMain/kotlin/com/sunya/netchdf/hdf5/MessageHeader.kt
@@ -554,6 +554,7 @@ internal fun H5builder.readFilterPipelineMessage(state: OpenFileState): FilterPi
     return FilterPipelineMessage(filters)
 }
 
+// H5Xpublic.h
 internal enum class FilterType(val id: Int) {
     none(0), deflate(1), shuffle(2), fletcher32(3), szip(4), nbit(5), scaleoffset(6),
     bzip2(307),
@@ -866,12 +867,12 @@ private fun H5builder.readAttributesFromInfoMessage(
 
     val btreeAddress: Long = attributeOrderBtreeAddress ?: attributeNameBtreeAddress
     if (btreeAddress < 0 || fractalHeapAddress < 0) return emptyList()
-    val btree = BTree2(this, "AttributeInfoMessage", btreeAddress)
+    val btree2 = BTree2(this, "AttributeInfoMessage", btreeAddress)
     val fractalHeap = FractalHeap(this, "AttributeInfoMessage", fractalHeapAddress)
 
     val list = mutableListOf<AttributeMessage>()
-    for (e in btree.entryList) {
-        val heapId: ByteArray = when (btree.btreeType) {
+    for (e in btree2.readEntries()) {
+        val heapId: ByteArray = when (btree2.btreeType) {
             8 -> (e.record as BTree2.Record8).heapId
             9 -> (e.record as BTree2.Record9).heapId
             else -> continue

--- a/core/src/commonTest/kotlin/com/sunya/netchdf/NetchdfTest.kt
+++ b/core/src/commonTest/kotlin/com/sunya/netchdf/NetchdfTest.kt
@@ -56,25 +56,39 @@ class NetchdfTest {
         readNetchdfData(filename, "DQF", SectionPartial.fromSpec(":, :"))
     }
 
-    @Test
+    // @Test
     fun testNetchIterate() {
         //  *** double UpperDeschutes_t4p10_swemelt[8395, 781, 385] skip read ArrayData too many bytes= 2524250575
         //compareNetchIterate(testData + "cdmUnitTest/formats/netcdf4/UpperDeschutes_t4p10_swemelt.nc", "UpperDeschutes_t4p10_swemelt")
     }
 
     @Test
-    fun testProblem() {
-        readNetchdfData(testData + "hdf4/96108_08.hdf", "graphics")
+    fun testFractalHeap() {
+        showNetchdfHeader(testData + "cdmUnitTest/formats/hdf5/SMAP_L4_SM_aup_20140115T030000_V05007_001.h5")
     }
 
     @Test
-    fun testSimple() {
-        //  *** double UpperDeschutes_t4p10_swemelt[8395, 781, 385] skip read ArrayData too many bytes= 2524250575
+    fun testSimpleXY() {
         readNetchdfData(testData + "devcdm/netcdf3/simple_xy.nc", showData = true)
+    }
+
+    // this is working
+    @Test
+    fun readBtreeVer1() {
+        readNetchdfData("/home/all/testdata/cdmUnitTest/formats/hdf5/OMI-Aura_L2-OMTO3_2009m0829t1219-o27250_v003-2009m0829t175727-2.he5",
+            "/HDFEOS/SWATHS/OMI_Column_Amount_O3/Data_Fields/fc", showCdl = false, showData = false)
+    }
+
+    // this is working
+    @Test
+    fun readBtreeVer1complex() {
+        readNetchdfData("/home/all/testdata/cdmUnitTest/formats/hdf5/OMI-Aura_L2-OMTO3_2009m0829t1219-o27250_v003-2009m0829t175727-2.he5",
+            "/HDFEOS/SWATHS/OMI_Column_Amount_O3/Data_Fields/fc", showCdl = false, showData = true)
     }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 
+     // fails on hdf5 /home/all/testdata/devcdm/netcdf4/vlenInt.nc
     @Test
     fun checkVersion() {
         files().forEach { filename ->

--- a/core/src/commonTest/kotlin/com/sunya/netchdf/hdf5/H5readTest.kt
+++ b/core/src/commonTest/kotlin/com/sunya/netchdf/hdf5/H5readTest.kt
@@ -114,6 +114,8 @@ class H5readTest {
         files().forEach { filename ->
             openH5(filename, null)
         }
+        println("mdlClassCount")
+        mdlClassCount.forEach { (key, value) -> println("  ${key} == ${value}") }
     }
 
     @Test

--- a/core/src/commonTest/kotlin/com/sunya/netchdf/hdf5/H5superblockTest.kt
+++ b/core/src/commonTest/kotlin/com/sunya/netchdf/hdf5/H5superblockTest.kt
@@ -358,6 +358,13 @@ class H5superblockTest {
         assertTrue(ok)
     }
 
+    @Test
+    fun testBTreeVer2() {
+        val filename = "/home/all/testdata/netcdf-c_hdf5_superblocks/netcdf-c-test-files/v1_10/nc_test4__tst_dims3.nc"
+        val ok = openH5(filename, "var", showCdl = true)
+        assertTrue(ok)
+    }
+
     ////////////////////////////////////////////////////////////////
     @Test
     fun testOpenSuperblockUnmodified() {


### PR DESCRIPTION
Btree1 add nDimStorage
BTree2 refactored, getEntry1() -> readEntries(), Entry2 -> InternalNode

H5chunkIterator BTree1(h5, vinfo.dataPos, 1, v2.shape, vinfo.storageDims) ->
    BTree1(h5, vinfo.dataPos, 1, vinfo.storageDims.size)

H5chunkReader.readChunkedData() -? readBtreeVer12(), uses DataChunkEntryIF

FractalHeap monstrosity

H5TiledData val tiling = Tiling(varShape, chunkShape) H5TiledData12

Hdf5File.readArrayData remove "if (vinfo.mdl is DataLayoutBTreeVer1)";
   add "else if (vinfo.mdl is DataLayoutBTreeVer1 || vinfo.mdl is DataLayoutBtreeVer2)";
   add "(vinfo.mdl is DataLayoutBTreeVer1)"

DataMessageLayout.DataLayoutChunked -> DataLayoutBTreeVer1

H5builder.readAttributesFromInfoMessage use BTree2