### PR TITLE
Compare cdm objects, cant use cdl.

### DIFF
--- a/core/src/commonMain/kotlin/com/sunya/cdm/api/Datatype.kt
+++ b/core/src/commonMain/kotlin/com/sunya/cdm/api/Datatype.kt
@@ -52,30 +52,16 @@ data class Datatype<T>(val cdlName: String, val size: Int, val typedef : Typedef
         return if (this == VLEN) "$cdlName ${typedef?.baseType?.cdlName}" else cdlName
     }
 
-    val isVlenString: Boolean
-        get() = (this == STRING) && (isVlen != null) && isVlen
-
-    val isNumeric: Boolean
-        get() = isFloatingPoint || isIntegral
-
+    val isVlenString = (this == STRING) && (isVlen != null) && isVlen
     // subclass of Number
-    val isNumber: Boolean
-        get() = (this == FLOAT) || (this == DOUBLE) || (this == BYTE) || (this == INT) || (this == SHORT) ||
-                (this == LONG)
-
-    val isUnsigned: Boolean
-        get() = (this == UBYTE) || (this == USHORT) || (this == UINT) || (this == ULONG) || isEnum
-
-    val isIntegral: Boolean
-        get() = ((this == BYTE) || (this == INT) || (this == SHORT) || (this == LONG)
+    val isNumber = (this == FLOAT) || (this == DOUBLE) || (this == BYTE) || (this == INT) || (this == SHORT) || (this == LONG)
+    val isEnum = (this == ENUM1) || (this == ENUM2) || (this == ENUM4) || (this == ENUM8)
+    val isUnsigned = (this == UBYTE) || (this == USHORT) || (this == UINT) || (this == ULONG) || isEnum
+    val isIntegral = ((this == BYTE) || (this == INT) || (this == SHORT) || (this == LONG)
                 || (this == UBYTE) || (this == UINT) || (this == USHORT)
                 || (this == ULONG))
-
-    val isFloatingPoint: Boolean
-        get() = (this == FLOAT) || (this == DOUBLE)
-
-    val isEnum: Boolean
-        get() = (this == ENUM1) || (this == ENUM2) || (this == ENUM4) || (this == ENUM8)
+    val isFloatingPoint = (this == FLOAT) || (this == DOUBLE)
+    val isNumeric = isFloatingPoint || isIntegral
 
     /**
      * Returns the DataType that is related to `this`, but with the specified signedness.

--- a/core/src/commonMain/kotlin/com/sunya/cdm/api/Dimension.kt
+++ b/core/src/commonMain/kotlin/com/sunya/cdm/api/Dimension.kt
@@ -11,4 +11,27 @@ data class Dimension(val orgName : String, val length : Long, val isShared : Boo
     constructor(name : String, len : Int) : this(name, len.toLong(), true)
     constructor(len : Int) : this("", len.toLong(), false)
     constructor(len : Long) : this("", len, false)
+
+    // orgName may be different
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as Dimension
+
+        if (length != other.length) return false
+        if (isShared != other.isShared) return false
+        if (name != other.name) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = length.hashCode()
+        result = 31 * result + isShared.hashCode()
+        result = 31 * result + name.hashCode()
+        return result
+    }
+
+
 }

--- a/core/src/commonMain/kotlin/com/sunya/netchdf/hdf4/H4builder.kt
+++ b/core/src/commonMain/kotlin/com/sunya/netchdf/hdf4/H4builder.kt
@@ -938,8 +938,8 @@ class H4builder(val raf: OpenFileIF, val valueCharset: Charset) {
         vinfo.setVariable(vb)
 
         // assume dimensions are not shared
-        vb.dimensions.add(Dimension("ydim", dimTag!!.ydim.toLong(), false))
-        vb.dimensions.add(Dimension("xdim", dimTag!!.xdim.toLong(), false))
+        vb.dimensions.add(Dimension("", dimTag!!.ydim.toLong(), false))
+        vb.dimensions.add(Dimension("", dimTag!!.xdim.toLong(), false))
 
         if (ip8Tag != null) {
             val lutv_name = "${name}_lookup"

--- a/core/src/commonMain/kotlin/com/sunya/netchdf/hdf5/H5typedef.kt
+++ b/core/src/commonMain/kotlin/com/sunya/netchdf/hdf5/H5typedef.kt
@@ -174,7 +174,7 @@ private fun H5builder.buildEnumTypedef(name : String, mess: DatatypeEnum, gb: Gr
     val typedef =  typedefManager.findTypedef(mess.address, mess.hashCode())
     if (typedef is EnumTypedef) return typedef
 
-    val enumTypedef = EnumTypedef(name, mess.datatype, mess.valuesMap)
+    val enumTypedef = EnumTypedef(name, mess.basetype, mess.valuesMap)
     typedefManager.registerTypedef(makeH5TypeInfo(mess, enumTypedef), gb)
     return enumTypedef
 }
@@ -185,7 +185,7 @@ private fun H5builder.buildVlenTypedef(name : String, mess: DatatypeVlen, gb: Gr
 
     val h5info = this.makeH5TypeInfo(mess.base)
     val datatype = h5info.datatype()
-    val altname = "${datatype.cdlName}(*)" // dont use the typedef name or member name
+    val altname = if (mess.isShared) name else "${datatype.cdlName}(*)" // dont use the typedef name or member name
     return VlenTypedef(altname, h5info.datatype())
 }
 

--- a/core/src/commonMain/kotlin/com/sunya/netchdf/hdf5/MessageDataType.kt
+++ b/core/src/commonMain/kotlin/com/sunya/netchdf/hdf5/MessageDataType.kt
@@ -39,8 +39,8 @@ enum class Datatype5(val num : Int) {
         }
     }
 
-    fun isTypedef() : Boolean {
-        return (num == 5) || (num == 6) || (num == 8) || (num == 9)
+    fun needsTypedef() : Boolean {
+        return (num == 6) || (num == 8) || (num == 9)
     }
 }
 
@@ -226,6 +226,7 @@ internal class DatatypeEnum(
 ) : DatatypeMessage(address, Datatype5.Enumerated, elemSize, isBT) {
     val valuesMap : Map<Int, String>
     val datatype : Datatype<*>
+    val basetype : Datatype<*>
 
     init {
         require(names.size == nums.size)
@@ -238,6 +239,14 @@ internal class DatatypeEnum(
             2 -> Datatype.ENUM2
             4 -> Datatype.ENUM4
             8 -> Datatype.ENUM8
+            else -> throw RuntimeException("invalid enum elemsize $elemSize")
+        }
+
+        basetype = when (elemSize) {
+            1 -> Datatype.UBYTE
+            2 -> Datatype.USHORT
+            4 -> Datatype.UINT
+            8 -> Datatype.ULONG
             else -> throw RuntimeException("invalid enum elemsize $elemSize")
         }
     }

--- a/testclibs/src/main/kotlin/com/sunya/netchdf/netcdfClib/UserTypes.kt
+++ b/testclibs/src/main/kotlin/com/sunya/netchdf/netcdfClib/UserTypes.kt
@@ -71,9 +71,12 @@ internal fun NCheader.readUserTypes(session: Arena, grpid: Int, gb: Group.Builde
             NC_ENUM() -> {
                 val values: Map<Int, String> = readEnumTypedef(session, grpid, userTypeId)
                 val baseType = when (baseTypeId) {
-                    NC_CHAR(), NC_UBYTE(), NC_BYTE() -> Datatype.ENUM1
-                    NC_USHORT(), NC_SHORT() -> Datatype.ENUM2
-                    NC_UINT(), NC_INT() -> Datatype.ENUM4
+                    NC_CHAR(), NC_UBYTE(), NC_BYTE() -> Datatype.UBYTE
+                    NC_BYTE() -> Datatype.BYTE
+                    NC_USHORT() -> Datatype.USHORT
+                    NC_SHORT() -> Datatype.SHORT
+                    NC_UINT() -> Datatype.UINT
+                    NC_INT() -> Datatype.INT
                     else -> throw RuntimeException("enum illegal baseType = $baseTypeId")
                 }
                 EnumTypedef(name, baseType, values)

--- a/testclibs/src/test/kotlin/com/sunya/netchdf/CompareNetchdf.kt
+++ b/testclibs/src/test/kotlin/com/sunya/netchdf/CompareNetchdf.kt
@@ -1,0 +1,158 @@
+package com.sunya.netchdf
+
+import com.sunya.cdm.api.Attribute
+import com.sunya.cdm.api.CompoundTypedef
+import com.sunya.cdm.api.Datatype
+import com.sunya.cdm.api.EnumTypedef
+import com.sunya.cdm.api.Group
+import com.sunya.cdm.api.Netchdf
+import com.sunya.cdm.api.OpaqueTypedef
+import com.sunya.cdm.api.Typedef
+import com.sunya.cdm.api.Variable
+import com.sunya.cdm.api.VlenTypedef
+import com.sunya.cdm.util.Indent
+import com.sunya.netchdf.hdf4Clib.Hdf4ClibFile
+import com.sunya.netchdf.hdf5Clib.Hdf5ClibFile
+import com.sunya.netchdf.netcdfClib.NClibFile
+import org.junit.jupiter.api.assertNotNull
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.test.fail
+import kotlin.use
+
+class CompareNetchdf(filename: String, showCdl: Boolean = false, val showCompare: Boolean = false) {
+    init {
+        println("=============================================================")
+        openNetchdfFile(filename).use { netchdf ->
+            if (netchdf == null) {
+                println("*** not a netchdf file = $filename")
+            } else {
+                println("${netchdf.type()} $filename ${"%.2f".format(netchdf.size / 1000.0 / 1000.0)} Mbytes")
+                if (showCdl) println("\nnetchdf ${netchdf.cdl()}")
+
+                if (netchdf.type().contains("hdf4") || netchdf.type().contains("hdf-eos2")) {
+                    Hdf4ClibFile(filename).use { ncfile ->
+                        if (showCdl) println("\nHdf4ClibFile ${ncfile.cdl()}")
+                        compareNetchdf(netchdf, ncfile, Indent(2, startingLevel=0))
+                    }
+                } else if (netchdf.type().contains("netcdf")) {
+                    NClibFile(filename).use { ncfile ->
+                        if (showCdl) println("\nNClibFile ${ncfile.cdl()}")
+                        compareNetchdf(netchdf, ncfile, Indent(2, startingLevel=0))
+                    }
+                } else if (netchdf.type().contains("hdf5") || netchdf.type().contains("hdf-eos5")) {
+                    Hdf5ClibFile(filename).use { ncfile ->
+                        if (showCdl) println("\nHdf5ClibFile ${ncfile.cdl()}")
+                        compareNetchdf(netchdf, ncfile, Indent(2, startingLevel=0))
+                    }
+                } else {
+                    println("*** no c library to compare for $filename")
+                }
+            }
+        }
+    }
+
+    fun compareNetchdf(myfile: Netchdf, cfile: Netchdf, indent: Indent) {
+        compareGroup(myfile.rootGroup(), cfile.rootGroup(), indent)
+    }
+
+    fun compareGroup(group: Group, cgroup: Group, indent: Indent) {
+        if (showCompare) {
+            println("${indent}group  $group")
+            println("${indent}cgroup $cgroup")
+        }
+
+        group.attributes.forEach { att ->
+            val catt = cgroup.findAttribute(att.name)!!
+            compareAttribute(att, catt, indent.incr())
+        }
+
+        group.variables.forEach { v ->
+            val cv = cgroup.variables.find { it.name == v.name }!!
+            compareVariable(v, cv, indent.incr())
+        }
+
+        group.groups.forEach { nested ->
+            val cnested = cgroup.findNestedGroupByShortName(nested.name)!!
+            compareGroup(nested, cnested, indent.incr())
+        }
+    }
+
+    fun compareAttribute(att: Attribute<*>, catt: Attribute<*>, indent: Indent) {
+        if (showCompare) {
+            println("${indent}att  $att")
+            println("${indent}catt $catt")
+        }
+        assertEquals(att.name, catt.name)
+        if (att.datatype == Datatype.OPAQUE) {
+            att.values.forEachIndexed { idx, it ->
+                val bval = it as ByteArray
+                val cval = catt.values[idx] as ByteArray
+                assertTrue(bval.contentEquals(cval))
+            }
+        } else {
+            assertEquals(att.values, catt.values)
+        }
+    }
+
+    fun compareVariable(v: Variable<*>, cv: Variable<*>, indent: Indent) {
+        if (showCompare) {
+            println("${indent}v  ${v.nameAndShape()}")
+            println("${indent}cv ${cv.nameAndShape()}")
+        }
+        assertEquals(v.name, cv.name)
+        assertEquals(v.dimensions, cv.dimensions)
+
+        v.attributes.forEach { att ->
+            val catt = cv.findAttribute(att.name)!!
+            compareAttribute(att, catt, indent.incr())
+        }
+
+        compareDatatype(v.datatype, cv.datatype, indent.incr())
+    }
+
+    fun compareDatatype(datatype: Datatype<*>, cdatatype: Datatype<*>, indent: Indent) {
+        if (showCompare) {
+            println("${indent}datatype  ${datatype}")
+            println("${indent}cdatatype ${cdatatype}")
+        }
+        assertEquals (datatype.cdlName, cdatatype.cdlName)
+        compareTypedef(datatype.typedef, cdatatype.typedef, indent)
+    }
+
+    fun compareTypedef(t: Typedef?, ct: Typedef?, indent: Indent) {
+        if ((t == null) && (ct == null)) return
+        if ((t == null) && (ct != null)) {
+            fail("typedef missing; ctypedef = ${ct}")
+        }
+        if ((t != null) && (ct == null)) {
+            fail("ctypedef missing; typedef = ${t}")
+        }
+        assertNotNull(t)
+        assertNotNull(ct)
+
+        if (showCompare) {
+            println("${t.cdl(indent)}")
+            println("${ct.cdl(indent)}")
+        }
+
+        assertEquals(t.kind, ct.kind)
+        assertEquals(t.baseType, ct.baseType)
+
+        if (t is OpaqueTypedef) {
+            assertTrue(ct is OpaqueTypedef)
+            assertEquals(t.elemSize, ct.elemSize)
+
+        } else if (t is VlenTypedef) {
+            assertTrue(ct is VlenTypedef)
+
+        } else if (t is EnumTypedef) {
+            assertTrue(ct is EnumTypedef)
+            assertEquals(t.valueMap, ct.valueMap)
+
+        } else if (t is CompoundTypedef) {
+            assertTrue(ct is CompoundTypedef)
+            assertEquals(t.members, ct.members)
+        }
+    }
+}

--- a/testclibs/src/test/kotlin/com/sunya/netchdf/KnownProblemFiles.kt
+++ b/testclibs/src/test/kotlin/com/sunya/netchdf/KnownProblemFiles.kt
@@ -18,14 +18,14 @@ class KnownProblemFiles {
     @Test
     fun testConfuseHdf5WithNetcdf4() {
         val filename = testData + "/netchdf/knox/SATMS_justdims_npp_d20120619_t1121416_e1122133_b03335_c20120619200237705890_noaa_ops.h5"
-        // compareCdlWithClib(filename, true)
+        // CompareNetchdf(filename, true)
         compareDataWithClib(filename, "Granule")
     }
 
     @Test
     fun testConfusedHdf5() {
         val filename = testData + "/netchdf/knox/SATMS_justdims_npp_d20120619_t1121416_e1122133_b03335_c20120619200237705890_noaa_ops.h5"
-        // compareCdlWithClib(filename, true)
+        // CompareNetchdf(filename, true)
         compareDataWithHdf5Clib(filename, "Granule", null)
     }
     /* tst_grps
@@ -71,7 +71,7 @@ group: the_out_crowd {
 } */
     @Test
     fun tst_grps() {
-        compareCdlWithClib(testData + "devcdm/netcdf4/tst_grps.nc4")
+        CompareNetchdf(testData + "devcdm/netcdf4/tst_grps.nc4")
     }
 
     @Test
@@ -84,7 +84,7 @@ group: the_out_crowd {
     //      float field3 ;
     //    }; // compound_att_float
     fun compoundAttributeTest() {
-        compareCdlWithClib(testData + "cdmUnitTest/formats/netcdf4/compound-attribute-test.nc")
+        CompareNetchdf(testData + "cdmUnitTest/formats/netcdf4/compound-attribute-test.nc")
     }
 
     // We use HDFEOS_INFORMATION to modify the structure, Nclib does not.
@@ -280,13 +280,13 @@ group: the_out_crowd {
 
     @Test
     fun problemTruncated() {
-        compareCdlWithClib(problemDir + "OMI-Aura_L2-OMTO3_2009m0829t1219-o27250_v003-2009m0829t175727.he5")
+        CompareNetchdf(problemDir + "OMI-Aura_L2-OMTO3_2009m0829t1219-o27250_v003-2009m0829t175727.he5")
     }
 
     @Test
     fun problem() {
         val filename = problemDir + "RAD_NL25_PCP_NA_200804110600.h5"
-        compareCdlWithClib(filename)
+        CompareNetchdf(filename)
         compareDataWithClib(filename)
     }
 
@@ -294,18 +294,9 @@ group: the_out_crowd {
     @Test
     fun problem2() {
         val filename = testData + "netchdf/gilmore/data.nc"
-        compareCdlWithClib(filename)
+        CompareNetchdf(filename)
         compareDataWithClib(filename)
     }
-
-    // yikes, wtf? dont they know what arrays are? consider these damaged
-    @Test
-    fun testIASI() {
-        val filename = testData + "cdmUnitTest/formats/hdf5/IASI/IASI_xxx_1C_M02_20070704193256Z_20070704211159Z_N_O_20070704211805Z.h5"
-        compareCdlWithClib(filename)
-        compareDataWithClib(filename)
-    }
-
 
     // not picking up missing value ??
     //  *** FAIL comparing data for variable = ubyte Granule [Granule]

--- a/testclibs/src/test/kotlin/com/sunya/netchdf/NetchdfClibExtra.kt
+++ b/testclibs/src/test/kotlin/com/sunya/netchdf/NetchdfClibExtra.kt
@@ -35,7 +35,7 @@ class NetchdfClibExtra {
     @Test
     fun problemNPP() {
         val filename = testData + "netchdf/npp/VCBHO_npp_d20030125_t084955_e085121_b00015_c20071213022754_den_OPS_SEG.h5"
-        compareCdlWithClib(filename)
+        CompareNetchdf(filename)
         readNetchdfData(filename, null)
         compareDataWithClib(filename)
     }
@@ -46,9 +46,18 @@ class NetchdfClibExtra {
         // showMyHeader(filename)
         showNcHeader(filename)
         // showMyData(filename)
-        compareCdlWithClib(filename)
+        CompareNetchdf(filename)
         //readDataCompareNC(filename)
     }
+
+    @Test
+    fun problem() {
+        val filename = testData + "netchdf/bird/watlev_NOAA.F.C_IKE_VIMS_3D_WITHWAVE.nc"
+        CompareNetchdf(filename)
+        readNetchdfData(filename, null)
+        compareDataWithClib(filename)
+    }
+
 
     ///////////////////////////////////////////////////////
     @Test
@@ -69,7 +78,7 @@ class NetchdfClibExtra {
     @Test
     fun testCompareCdlWithClib() {
         files().forEach { filename ->
-            compareCdlWithClib(filename, showCdl = true)
+            CompareNetchdf(filename, showCdl = true)
         }
     }
 

--- a/testclibs/src/test/kotlin/com/sunya/netchdf/TestNPP.kt
+++ b/testclibs/src/test/kotlin/com/sunya/netchdf/TestNPP.kt
@@ -175,7 +175,7 @@ What we get though are just the last part of the names, not a full path:
     @Test
     fun problemNPP() {
         val filename = testData + "netchdf/npp/VCBHO_npp_d20030125_t084955_e085121_b00015_c20071213022754_den_OPS_SEG.h5"
-        compareCdlWithClib(filename, showCdl = true)
+        CompareNetchdf(filename, showCdl = true)
         readNetchdfData(filename, )
         compareDataWithClib(filename, )
     }

--- a/testclibs/src/test/kotlin/com/sunya/netchdf/hdf5/Hdf5Compare.kt
+++ b/testclibs/src/test/kotlin/com/sunya/netchdf/hdf5/Hdf5Compare.kt
@@ -31,21 +31,21 @@ class Hdf5Compare {
     @Test
     fun testNewLibrary() {
         val filename = testData + "netchdf/haberman/iso.h5"
-        compareCdlWithClib(filename, showCdl = true)
+        CompareNetchdf(filename, showCdl = true)
         compareDataWithClib(filename)
     }
 
     @Test
     fun problemChars() {
         val filename = testData + "cdmUnitTest/formats/netcdf4/files/c0_4.nc4"
-        compareCdlWithClib(filename)
+        CompareNetchdf(filename)
         compareDataWithClib(filename)
     }
 
     @Test
     fun problemLibraryVersion() {
         val filename = testData + "devcdm/netcdf4/tst_solar_cmp.nc"
-        compareCdlWithClib(filename, showCdl = true)
+        CompareNetchdf(filename, showCdl = true)
         compareDataWithClib(filename)
     }
 
@@ -58,7 +58,7 @@ class Hdf5Compare {
     @Test
     fun problem() {
         val filename = testData + "cdmUnitTest/formats/netcdf4/files/xma022032.nc"
-        compareCdlWithClib(filename)
+        CompareNetchdf(filename)
         compareDataWithClib(filename)
     }
 
@@ -80,7 +80,7 @@ class Hdf5Compare {
     @Test
     fun testCdlWithClib() {
         files().forEach { filename ->
-            compareCdlWithClib(filename)
+            CompareNetchdf(filename)
         }
     }
 

--- a/testclibs/src/test/kotlin/com/sunya/netchdf/hdf5/Hdf5openTest.kt
+++ b/testclibs/src/test/kotlin/com/sunya/netchdf/hdf5/Hdf5openTest.kt
@@ -84,25 +84,25 @@ class Hdf5openTest {
 
     @Test
     fun vlstra() {
-        compareCdlWithClib(testData + "devcdm/hdf5/vlstra.h5")
+        CompareNetchdf(testData + "devcdm/hdf5/vlstra.h5")
     }
 
     //// the following wont work opening as netcdf
     @Test
     fun notNetcdf() {
-        compareCdlWithClib(testData + "devcdm/hdf5/compound_complex.h5", showCdl = true)
-        compareCdlWithClib(testData + "devcdm/hdf5/bitfield.h5", showCdl = true)
-        compareCdlWithClib(testData + "devcdm/hdf5/SDS_array_type.h5", showCdl = true)
+        CompareNetchdf(testData + "devcdm/hdf5/compound_complex.h5", showCdl = true)
+        CompareNetchdf(testData + "devcdm/hdf5/bitfield.h5", showCdl = true)
+        CompareNetchdf(testData + "devcdm/hdf5/SDS_array_type.h5", showCdl = true)
     }
 
     @Test
     fun privateTypedef() {
-        compareCdlWithClib(testData + "devcdm/hdf5/bitop.h5", showCdl = true)
+        CompareNetchdf(testData + "devcdm/hdf5/bitop.h5", showCdl = true)
     }
 
     @Test
     fun problemCompareCdl() {
-        compareCdlWithClib(testData + "devcdm/netcdf4/testNestedStructure.nc", showCdl = true)
+        CompareNetchdf(testData + "devcdm/netcdf4/testNestedStructure.nc", showCdl = true)
     }
 
     ///////////////////////////////////////////////////////////////////////////////////
@@ -130,7 +130,7 @@ class Hdf5openTest {
     @Test
     fun testCdlWithClibAll() {
         files().forEach { filename ->
-            compareCdlWithClib(filename)
+            CompareNetchdf(filename)
         }
     }
 

--- a/testclibs/src/test/kotlin/com/sunya/netchdf/hdf5/JhdfReadTest.kt
+++ b/testclibs/src/test/kotlin/com/sunya/netchdf/hdf5/JhdfReadTest.kt
@@ -1,6 +1,6 @@
 package com.sunya.netchdf.hdf5
 
-import com.sunya.netchdf.compareCdlWithClib
+import com.sunya.netchdf.CompareNetchdf
 import com.sunya.netchdf.compareDataWithClib
 import com.sunya.netchdf.testfiles.JhdfFiles
 import kotlin.test.Test
@@ -21,25 +21,27 @@ class JhdfReadTest {
 
     @Test
     fun problem() {
-        compareCdlWithClib("../core/src/commonTest/data/jhdf/compound_datasets_earliest.hdf5", showCdl= true)
+        CompareNetchdf("../core/src/commonTest/data/jhdf/compound_datasets_earliest.hdf5", showCdl = true, showCompare = true)
+        // CompareNetchdf("../core/src/commonTest/data/jhdf/compound_datasets_earliest.hdf5", showCdl= true)
     }
 
     @Test
     fun problem2() {
-        compareCdlWithClib("../core/src/commonTest/data/jhdf/compound_datasets_latest.hdf5", showCdl= true)
+        CompareNetchdf("../core/src/commonTest/data/jhdf/compound_datasets_latest.hdf5", showCdl= true, showCompare = true)
     }
 
     @Test
     fun failure() {
-        compareCdlWithClib("../core/src/commonTest/data/jhdf/test_compound_scalar_attribute.hdf5", showCdl= true)
+        CompareNetchdf("../core/src/commonTest/data/jhdf/globalheaps_test.hdf5", showCdl= true, showCompare = true)
     }
 
     @Test
-    fun compareCdlWithClib() {
+    fun compareNetchdf() {
         files().forEach { filename ->
             try {
-                compareCdlWithClib(filename)
+                CompareNetchdf(filename, false, false)
             } catch (e: Throwable) {
+                CompareNetchdf(filename, true, true)
                 e.printStackTrace()
             }
         }

--- a/testclibs/src/test/kotlin/com/sunya/netchdf/hdf5Clib/H5CopenTest.kt
+++ b/testclibs/src/test/kotlin/com/sunya/netchdf/hdf5Clib/H5CopenTest.kt
@@ -32,7 +32,7 @@ class H5CopenTest {
 
     @Test
     fun problemReferenceObjects() {
-        compareCdlWithClib(testData + "cdmUnitTest/formats/hdf5/msg/test.h5")
+        CompareNetchdf(testData + "cdmUnitTest/formats/hdf5/msg/test.h5")
     }
 
     @Test
@@ -40,12 +40,12 @@ class H5CopenTest {
         val filename = testData + "cdmUnitTest/formats/hdf5/aura/MLS-Aura_L2GP-BrO_v01-52-c01_2007d029.he5"
         //showNetchdfHeader(filename)
         //readNetchdfData(filename)
-        compareCdlWithClib(filename)
+        CompareNetchdf(filename)
     }
 
     @Test
     fun dimScales() {
-        compareCdlWithClib(testData + "cdmUnitTest/formats/hdf5/extLink/JA2_IPR_2PcP021_001_20090126_085038_20090126_094651.nc")
+        CompareNetchdf(testData + "cdmUnitTest/formats/hdf5/extLink/JA2_IPR_2PcP021_001_20090126_085038_20090126_094651.nc")
     }
 
     // netcdf cstr.h5 {
@@ -60,7 +60,7 @@ class H5CopenTest {
     @Test
     fun fixlengthStringsInCompound() {
         val filename = testData + "devcdm/hdf5/cstr.h5"
-        compareCdlWithClib(filename)
+        CompareNetchdf(filename)
         readNetchdfData(filename, "Compound_String")
         compareDataWithClib(filename)
     }
@@ -82,7 +82,7 @@ class H5CopenTest {
     @Test
     fun vlenStringsInCompound() {
         val filename = testData + "devcdm/hdf5/compound_complex.h5"
-        // compareCdlWithClib(filename)
+        // CompareNetchdf(filename)
         // readNetchdfData(filename, "CompoundComplex")
         openH5C(filename, "CompoundComplex")
         // compareDataWithClib(filename)
@@ -96,7 +96,7 @@ class H5CopenTest {
     @Test
     fun compactStorage() {
         val filename = testData + "devcdm/hdf5/matlab_cols.mat"
-        compareCdlWithClib(filename)
+        CompareNetchdf(filename)
         readNetchdfData(filename, "b")
         openH5C(filename, "b")
         compareDataWithClib(filename)
@@ -105,7 +105,7 @@ class H5CopenTest {
     @Test
     fun problem() {
         val filename = testData + "devcdm/hdf5/SDS_array_type.h5"
-        compareCdlWithClib(filename)
+        CompareNetchdf(filename)
         compareDataWithClib(filename, "IntArray")
     }
 
@@ -114,7 +114,7 @@ class H5CopenTest {
     // but netcdf4   /home/all/testdata/cdmUnitTest/formats/hdf5/extLink/JA2_IPR_2PcP021_001_20090126_085038_20090126_094651.nc seems to work
     fun externalLinks() {
         val filename = testData + "formats/hdf5/extLink/extlink_source.h5"
-        compareCdlWithClib(filename)
+        CompareNetchdf(filename)
         compareDataWithClib(filename, "IntArray")
     }
 
@@ -122,7 +122,7 @@ class H5CopenTest {
     fun testConfuseHdf5WithNetcdf4() {
         val filename =
             testData + "/netchdf/knox/SATMS_justdims_npp_d20120619_t1121416_e1122133_b03335_c20120619200237705890_noaa_ops.h5"
-        // compareCdlWithClib(filename, true)
+        // CompareNetchdf(filename, true)
         compareDataWithHdf5Clib(filename, "Granule")
     }
 
@@ -153,7 +153,7 @@ class H5CopenTest {
     @Test
     fun testCdlWithH5Clib() {
         files().forEach { filename ->
-            compareCdlWithClib(filename)
+            CompareNetchdf(filename)
         }
     }
 


### PR DESCRIPTION
compareCdlWithClib() -> CompareNetchdf()
Vlen attributes return lists, not arrays.
Enum typedefs have correct basetype.
No typedefs for Opaque.